### PR TITLE
Avoid calling unwrap or expect inside fn that returns Result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 [dependencies]
 blake2-rfc = "0.2.18"
 byteorder = "1.3.4"
-ed25519-dalek = "1.0.0-pre.3"
+ed25519-dalek = "=1.0.0-pre.3"
 anyhow = "1.0.26"
 flat-tree = "5.0.0"
 lazy_static = "1.4.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,7 @@ use hypercore::{Feed, Storage};
 
 async fn create_feed(page_size: usize) -> Result<Feed<RandomAccessMemory>, Error> {
     let storage =
-        Storage::new(|_| Box::pin(async move { Ok(RandomAccessMemory::new(page_size)) })).await?;
+        Storage::new(|_| Box::pin(async move { Ok(RandomAccessMemory::new(page_size)) },), true).await?;
     Feed::with_storage(storage).await
 }
 

--- a/src/bitfield/mod.rs
+++ b/src/bitfield/mod.rs
@@ -23,7 +23,6 @@ mod masks;
 use self::masks::Masks;
 use flat_tree::{self, Iterator as FlatIterator};
 pub use sparse_bitfield::{Bitfield as SparseBitfield, Change};
-use std::convert::TryInto;
 use std::ops::Range;
 
 /// Bitfield with `{data, tree, index} fields.`
@@ -76,10 +75,7 @@ impl Bitfield {
                     }
                 });
             });
-        let length = data
-            .len()
-            .try_into()
-            .expect("Failed to convert len:usize to length:u64");
+        let length = data.len() as u64;
         let s = Self {
             data,
             index,

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -90,7 +90,11 @@ where
                 }
 
                 builder
-                    .secret_key(partial_keypair.secret.unwrap())
+                    .secret_key(
+                        partial_keypair
+                            .secret
+                            .ok_or(anyhow::anyhow!("secret-key not present"))?,
+                    )
                     .build()
                     .await
             }

--- a/src/feed_builder.rs
+++ b/src/feed_builder.rs
@@ -63,14 +63,14 @@ where
             let idx = roots
                 .iter()
                 .position(|&x| x == node.index)
-                .expect("Couldnt find idx of node");
+                .ok_or(anyhow::anyhow!("Couldnt find idx of node"))?;
             result[idx] = Some(node);
         }
 
         let roots = result
             .into_iter()
-            .map(|node_option| node_option.unwrap())
-            .collect::<Vec<_>>();
+            .collect::<Option<Vec<_>>>()
+            .ok_or(anyhow::anyhow!("Roots contains undefined nodes"))?;
 
         let byte_length = roots.iter().fold(0, |acc, node| acc + node.length);
 
@@ -78,8 +78,8 @@ where
             merkle: Merkle::from_nodes(roots),
             byte_length,
             length: tree.blocks(),
-            bitfield: bitfield,
-            tree: tree,
+            bitfield,
+            tree,
             public_key: self.public_key,
             secret_key: self.secret_key,
             storage: self.storage,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -293,8 +293,8 @@ where
             .bitfield
             .read(0, 32)
             .await
-            .expect("read bitfield header");
-        let header = Header::from_vec(&buf).unwrap();
+            .map_err(|_| anyhow::anyhow!("read bitfield header"))?;
+        let header = Header::from_vec(&buf).map_err(|e| anyhow::anyhow!(e))?;
 
         // khodzha:
         // TODO: we should handle eof vs errors here somehow but idk how to do that


### PR DESCRIPTION
These are some improvements on the PR https://github.com/datrs/hypercore/pull/121

- Avoid calling unwrap or expect inside functions that return `Result`
- Pin ed25519-dalek function to a version that compiles, now that it has been released a `pre.4`
- Fixes the benchmarks compilation now there is a new required argument when creating the storage